### PR TITLE
Add 'npm start' command. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node-powered price scraper",
   "main": "regus_scraper.js",
   "scripts": {
+    "start": "node regus_scraper.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Now run the project by simply running `$ npm start` instead of `$ node price_scraper.js`. Works as the entry for any Node project. Very clean and easy to remember when bouncing around multiple projects with multiple JS files.
